### PR TITLE
Add initial dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM java:8-jre-alpine
+ADD twitch-api-v3-proxy-boot.tar /srv/
+
+RUN mkdir /etc/twitch-api-v3-proxy
+
+WORKDIR /etc/twitch-api-v3-proxy
+
+EXPOSE 7221
+
+ENTRYPOINT ["/srv/twitch-api-v3-proxy-boot/bin/twitch-api-v3-proxy"]


### PR DESCRIPTION
This PR adds an initial Dockerfile

I'm not a Docker expert so let me know if something is weird 

### Building the image
`docker build -t twitch-api-v3-proxy .`

### Running the image
Switch out the `$PWD/application.properties` with the place where you store your application.properties on your host machine
`docker run --rm --net=host -v "$PWD/application.properties":/etc/twitch-api-v3-proxy/application.properties twitch-api-v3-proxy`